### PR TITLE
Update DialogueRoutes.cs to fix null references

### DIFF
--- a/Src/Dialogue.Logic/Routes/DialogueRoutes.cs
+++ b/Src/Dialogue.Logic/Routes/DialogueRoutes.cs
@@ -68,6 +68,9 @@ namespace Dialogue.Logic.Routes
  
             foreach (var nodeSearch in nodesWithPath.GroupBy(x => x.GetPropertyValue<string>(AppConstants.PropMemberUrlName)))
             {
+                if (string.IsNullOrWhiteSpace(nodeSearch.Key))
+                    continue;
+                    
                 var routeHash = nodeSearch.Key.GetHashCode();
 
                 //Create the route for the /search/{term} results
@@ -95,6 +98,9 @@ namespace Dialogue.Logic.Routes
         {
             foreach (var nodeSearch in nodesWithPath.GroupBy(x => x.GetPropertyValue<string>(AppConstants.PropTopicUrlName)))
             {
+                if (string.IsNullOrWhiteSpace(nodeSearch.Key))
+                    continue;
+                    
                 var routeHash = nodeSearch.Key.GetHashCode();
 
                 //Create the route for the /search/{term} results
@@ -122,6 +128,9 @@ namespace Dialogue.Logic.Routes
 
             foreach (var nodeSearch in nodesWithPath.GroupBy(x => x.GetPropertyValue<string>(AppConstants.PropDialogueUrlName)))
             {
+                if (string.IsNullOrWhiteSpace(nodeSearch.Key))
+                    continue;
+                    
                 var routeHash = nodeSearch.Key.GetHashCode();
 
                 routes.MapUmbracoRoute(


### PR DESCRIPTION
If a forum does not contain any members, topics or Dialogue pages, the DialogueRoutes helper class tries to add routes with empty keys. This causes duplicate routes for some reason. This commit adds a check to make sure we have a key when adding a route.
