### PR TITLE
Fixes null reference check when removing Member Points

### DIFF
--- a/Src/Dialogue.Logic/Services/MemberPointsService.cs
+++ b/Src/Dialogue.Logic/Services/MemberPointsService.cs
@@ -62,6 +62,9 @@ namespace Dialogue.Logic.Services
 
         public void Delete(MemberPoints item)
         {
+            if (item == null)
+                return;
+                
             ContextPerRequest.Db.MemberPoints.Remove(item);
         }
 


### PR DESCRIPTION
The additional check sees if the passed Member Points instance is null or not. If null, the method will not attempt to remove any points. A null parameter is sometimes passed when deleting a topic.
