### PR TITLE
Add a check to see if any posts can be displayed on the Latest Topics

### DIFF
--- a/Src/Dialogue.Website/App_Plugins/Dialogue/Themes/Default/Views/Shared/LatestTopics.cshtml
+++ b/Src/Dialogue.Website/App_Plugins/Dialogue/Themes/Default/Views/Shared/LatestTopics.cshtml
@@ -22,16 +22,23 @@
     </div>
 </div>
 
-@foreach (var topic in Model.Topics)
+@if (Model.Topics.TotalCount > 0)
 {
-    // Get the permissions for this topic via its parent category
-    var permissions = Model.AllPermissionSets[topic.Category];
+    foreach (var topic in Model.Topics)
+    {
+        // Get the permissions for this topic via its parent category
+        var permissions = Model.AllPermissionSets[topic.Category];
 
-    var viewModel = new ViewTopicViewModel { Permissions = permissions, Topic = topic, User = Model.User, ShowCategoryName = true };
-    Html.RenderPartial(Dialogue.Logic.PathHelper.GetThemePartialViewPath("TopicRow"), viewModel);
+        var viewModel = new ViewTopicViewModel { Permissions = permissions, Topic = topic, User = Model.User, ShowCategoryName = true };
+        Html.RenderPartial(Dialogue.Logic.PathHelper.GetThemePartialViewPath("TopicRow"), viewModel);
+    }
+
+    if (Model.Topics.TotalPages > 1)
+    {
+        @Html.Pager(Convert.ToInt32(Model.PageIndex), Html.Settings().TopicsPerPage, totalCount, null)
+    }
 }
-
-@if (Model.Topics.TotalPages > 1)
+else
 {
-    @Html.Pager(Convert.ToInt32(Model.PageIndex), Html.Settings().TopicsPerPage, totalCount, null)
+    <p>@Html.Lang("Home.NoLatestDiscussions")</p>
 }


### PR DESCRIPTION
Added a check to see if any posts can be displayed on the Latest Topics partial. Now displays a "No Latest Discussions" dictionary Item if none are present, much like the Category view. The dictionary item needs adding to the database.
